### PR TITLE
S-536:Updating spark to not import MemoryAddress

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/Platform.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import jdk.internal.vm.memory.MemoryAddress;
 
 import sun.misc.Unsafe;
 

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/UnsafeMemoryAllocator.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/UnsafeMemoryAllocator.java
@@ -17,10 +17,7 @@
 
 package org.apache.spark.unsafe.memory;
 
-import jdk.internal.vm.memory.MemoryAddress;
 import org.apache.spark.unsafe.Platform;
-import jdk.internal.vm.memory.MemoryAddress;
-
 /**
  * A simple {@link MemoryAllocator} that uses {@code Unsafe} to allocate off-heap memory.
  */

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/UnsafeMemoryAllocator.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/memory/UnsafeMemoryAllocator.java
@@ -18,6 +18,7 @@
 package org.apache.spark.unsafe.memory;
 
 import org.apache.spark.unsafe.Platform;
+
 /**
  * A simple {@link MemoryAllocator} that uses {@code Unsafe} to allocate off-heap memory.
  */

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/OffHeapColumnVector.java
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution.vectorized;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import jdk.internal.vm.memory.MemoryAddress;
 
 import com.google.common.annotations.VisibleForTesting;
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/vectorized/ColumnarBatchBenchmark.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution.vectorized
 
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
-import jdk.internal.vm.memory.MemoryAddress
 
 import scala.util.Random
 


### PR DESCRIPTION
## Motivation
MemoryAddress class was moved to java.lang, which means to no longer needed importung
## Changes
Removed the import of the MemoryAddress class
## Test
Created a new renaissance jar with this repo, and ran it against the master zero-morello version of the jdk.